### PR TITLE
refs #4119 - hammer-manifest - do not convert params to_json since this ...

### DIFF
--- a/lib/foreman_api/base.rb
+++ b/lib/foreman_api/base.rb
@@ -66,7 +66,7 @@ module ForemanApi
 
       args = [http_method]
       if %w[post put].include?(http_method.to_s)
-        args << params.to_json
+        args << params
       else
         headers[:params] = params if params
       end


### PR DESCRIPTION
...prevents passing File objects to POST
