### PR TITLE
add configuration for ssl certificate verification

### DIFF
--- a/lib/foreman_api/base.rb
+++ b/lib/foreman_api/base.rb
@@ -48,6 +48,7 @@ module ForemanApi
         :timeout  => config[:timeout],
         :headers  => headers
       }.merge(options)
+      resource_config[:verify_ssl] = config[:verify_ssl] unless config[:verify_ssl].nil?
 
       @client = RestClient::Resource.new(config[:base_url], resource_config)
       @config = config


### PR DESCRIPTION
This commits implements the support for configuring ssl certificate
verification. by default it keeps the current behaviour.

It only configures the :verify_ssl parameter for rest_client if
the instance of foreman_api explicitly configure it.

example to disable the ssl verification:

hosts = ForemanApi::Resources::Host.new(
  {
    :base_url   => 'https://foreman.example.com',
    :username   => 'user',
    :password   => 'password',
    :verify_ssl => false
  })

This is needed because when we use puppet ca, it is a self signed certificate,
and the api could not verify it.

thanks
Rosano
