### PR TITLE
Add a notice so users know that apiepie is the preferred api.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,9 @@
 = Foreman API bindings for Ruby
 
+== NOTE
+
+Alternatively, you may want to take a look at {apipie-bindings}[https://github.com/Apipie/apipie-bindings]. It is the replacement for foreman_api that is used in the Foreman CLI. It has more frequent releases. Additional info at {apipie-bindings}[http://rubydoc.info/github/Apipie/apipie-bindings/frames/file/README.md].
+
 == Summary
 
 Usage:


### PR DESCRIPTION
Hello,

Per #28, I take it that you prefer people use the other api.

Added this notice to let people know.

Just close if I misinterpreted that issue.

Thanks for both APIs

--Keenan
